### PR TITLE
Add scroll animations and improve stack accessibility

### DIFF
--- a/src/components/sections/Stack/Stack.tsx
+++ b/src/components/sections/Stack/Stack.tsx
@@ -111,7 +111,10 @@ const Stack = () => {
 
   return (
     <div className="max-w-7xl flex flex-col items-start justify-center">
-      <section className="w-full flex flex-col space-y-4">
+      <section
+        aria-label="Technology stack"
+        className="w-full flex flex-col space-y-4"
+      >
         {categories.map((category) => {
           return (
             <StackCategory

--- a/src/components/sections/Stack/StackCategory.tsx
+++ b/src/components/sections/Stack/StackCategory.tsx
@@ -1,6 +1,9 @@
-import React from "react";
+"use client";
+import React, { useEffect } from "react";
 import Image from "next/image";
 import { cn } from "@/lib/utils";
+import { motion, useAnimation } from "framer-motion";
+import { useInView } from "react-intersection-observer";
 
 interface TechStackItem {
   name: string;
@@ -13,32 +16,68 @@ interface StackCategoryProps {
   items: TechStackItem[];
 }
 
+const container = {
+  hidden: { opacity: 0, y: 40 },
+  visible: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      staggerChildren: 0.1,
+      duration: 0.6,
+      ease: "easeOut",
+    },
+  },
+};
+
+const item = {
+  hidden: { opacity: 0, y: 20 },
+  visible: { opacity: 1, y: 0 },
+};
+
 const StackCategory: React.FC<StackCategoryProps> = ({ category, items }) => {
+  const controls = useAnimation();
+  const { ref, inView } = useInView({ triggerOnce: true, threshold: 0.2 });
+
+  useEffect(() => {
+    if (inView) {
+      controls.start("visible");
+    }
+  }, [controls, inView]);
+
   return (
-    <div className="py-4 grid grid-cols-1 sm:grid-cols-3">
-      <h2 className="text-white text-5xl font-semibold pb-8">
+    <motion.div
+      ref={ref}
+      variants={container}
+      initial="hidden"
+      animate={controls}
+      className="py-4 grid grid-cols-1 sm:grid-cols-3"
+    >
+      <h2 className="text-white text-3xl sm:text-5xl font-semibold pb-8">
         {category.toUpperCase()}
       </h2>
-      <div className="w-full grid grid-cols-1 sm:grid-cols-3 gap-8 col-span-2">
-        {items.map((item) => (
-          <div
-            key={item.name}
+      <div className="w-full grid grid-cols-2 sm:grid-cols-3 gap-8 col-span-2">
+        {items.map((itemData) => (
+          <motion.div
+            key={itemData.name}
+            variants={item}
             className="w-full flex items-center gap-4 justify-start"
           >
             <Image
-              src={item.icon}
-              alt={item.name}
+              src={itemData.icon}
+              alt={itemData.name}
               width={48}
               height={48}
               className={cn("object-contain", {
-                "filter invert": item.tint === "#FFFFFF",
+                "filter invert": itemData.tint === "#FFFFFF",
               })}
             />
-            <span className="text-white text-3xl">{item.name}</span>
-          </div>
+            <span className="text-white text-xl sm:text-3xl">
+              {itemData.name}
+            </span>
+          </motion.div>
         ))}
       </div>
-    </div>
+    </motion.div>
   );
 };
 


### PR DESCRIPTION
## Summary
- animate stack categories when they scroll into view
- adjust mobile typography and grid
- add aria label to stack section for better accessibility

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_b_685d3f2d6a98832d8632ed1e0d4dd45c