### PR TITLE
Add bilingual projects section

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -5,6 +5,7 @@ import About from "@/components/sections/About";
 import Contact from "@/components/sections/Contact";
 import Experience from "@/components/sections/Experience";
 import Main from "@/components/sections/Main";
+import Projects from "@/components/sections/Projects";
 import Stack from "@/components/sections/Stack/Stack";
 import { SectionContext, useSectionContextValues } from "@/lib/SectionContext";
 import { useEffect } from "react";
@@ -19,8 +20,9 @@ export default function Home() {
     { title: t("main"), positionId: 0, Component: Main, hideTitle: true },
     { title: t("about"), positionId: 1, Component: About },
     { title: t("stack"), positionId: 2, Component: Stack },
-    { title: t("experience"), positionId: 3, Component: Experience },
-    { title: t("contact"), positionId: 4, Component: Contact, hideTitle: true },
+    { title: t("projects"), positionId: 3, Component: Projects },
+    { title: t("experience"), positionId: 4, Component: Experience },
+    { title: t("contact"), positionId: 5, Component: Contact, hideTitle: true },
   ];
 
   useEffect(() => {

--- a/src/components/sections/Projects.tsx
+++ b/src/components/sections/Projects.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+
+interface ProjectHighlight {
+  id: string;
+  name: string;
+  tagline: string;
+  description: string;
+  highlights?: string[];
+}
+
+const Projects = () => {
+  const t = useTranslations("projects");
+  const projectsRaw = t.raw("items");
+  const projects = Array.isArray(projectsRaw)
+    ? (projectsRaw as ProjectHighlight[])
+    : [];
+
+  return (
+    <div className="w-full flex flex-col gap-8">
+      <header className="flex flex-col gap-3 text-center md:text-left">
+        <h2 className="text-3xl sm:text-4xl font-semibold text-white">
+          {t("title")}
+        </h2>
+        <p className="text-base sm:text-lg text-gray-400 max-w-3xl mx-auto md:mx-0">
+          {t("subtitle")}
+        </p>
+      </header>
+
+      <div className="grid gap-6 lg:gap-8 md:grid-cols-2">
+        {projects.map((project) => (
+          <article
+            key={project.id}
+            className="group relative flex h-full flex-col overflow-hidden rounded-2xl border border-white/10 bg-white/5 p-6 backdrop-blur transition-transform duration-300 hover:-translate-y-1 hover:border-white/20 hover:bg-white/10 dark:bg-white/5"
+          >
+            <div className="absolute inset-0 -z-10 bg-gradient-to-br from-white/10 via-transparent to-white/5 opacity-0 transition-opacity duration-300 group-hover:opacity-100" />
+            <div className="flex flex-col gap-2">
+              <span className="text-xs font-semibold uppercase tracking-[0.2em] text-sky-400">
+                {project.tagline}
+              </span>
+              <h3 className="text-2xl font-semibold text-white">{project.name}</h3>
+              <p className="text-sm sm:text-base text-gray-300 leading-relaxed">
+                {project.description}
+              </p>
+            </div>
+
+            {project.highlights?.length ? (
+              <ul className="mt-6 flex flex-wrap gap-2">
+                {project.highlights.map((highlight) => (
+                  <li
+                    key={highlight}
+                    className="rounded-full border border-white/10 bg-white/10 px-3 py-1 text-xs font-medium text-white/80 backdrop-blur-sm"
+                  >
+                    {highlight}
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Projects;

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -3,6 +3,7 @@
     "main": "HOME",
     "about": "ABOUT ME",
     "stack": "MY STACK",
+    "projects": "PROJECTS",
     "experience": "EXPERIENCE",
     "contact": "CONTACT"
   },
@@ -39,6 +40,45 @@
       "whatsapp": "WhatsApp"
     },
     "emailText": "Feel free to reach out via email at"
+  },
+  "projects": {
+    "title": "Featured work",
+    "subtitle": "A selection of products I've helped launch and evolve. Each one balances thoughtful UX with resilient engineering so teams can keep scaling with confidence.",
+    "items": [
+      {
+        "id": "pulse",
+        "name": "Pulse",
+        "tagline": "Fitness coaching OS",
+        "description": "Pulse is a fitness management platform built with React Native and Expo that gives trainers one command center for programs, payments, and client progress analytics.",
+        "highlights": [
+          "React Native & Expo",
+          "Progress tracking dashboards",
+          "Automated payment reminders"
+        ]
+      },
+      {
+        "id": "slive",
+        "name": "SLIVE.AI",
+        "tagline": "Enterprise collaboration",
+        "description": "SLIVE.AI unifies ERP operations, social collaboration, and conversational AI to help enterprises orchestrate their people, processes, and decisions in real time.",
+        "highlights": [
+          "ERP + social workspace",
+          "Conversational AI copilots",
+          "Workflow automation"
+        ]
+      },
+      {
+        "id": "burger",
+        "name": "Burger Smoke",
+        "tagline": "Digital menu & ordering",
+        "description": "Burger Smoke is a lightweight ordering experience that turns a dynamic web menu into WhatsApp-ready takeout requests for fast-moving local businesses.",
+        "highlights": [
+          "Real-time menu updates",
+          "WhatsApp order routing",
+          "Optimized for small teams"
+        ]
+      }
+    ]
   },
   "alt": {
     "wavingHand": "Waving Hand"

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -3,6 +3,7 @@
     "main": "INICIO",
     "about": "SOBRE MÍ",
     "stack": "MI STACK",
+    "projects": "PROYECTOS",
     "experience": "EXPERIENCIA",
     "contact": "CONTACTO"
   },
@@ -39,6 +40,45 @@
       "whatsapp": "WhatsApp"
     },
     "emailText": "No dudes en contactarme por correo electrónico en"
+  },
+  "projects": {
+    "title": "Proyectos destacados",
+    "subtitle": "Una selección de productos en los que he colaborado para lanzarlos y hacerlos crecer. Cada uno equilibra una experiencia cuidada con una ingeniería sólida para que los equipos sigan escalando con confianza.",
+    "items": [
+      {
+        "id": "pulse",
+        "name": "Pulse",
+        "tagline": "Plataforma para entrenadores",
+        "description": "Pulse es una plataforma de gestión fitness creada con React Native y Expo que ofrece a los entrenadores un centro de control para planes, pagos y analíticas de progreso.",
+        "highlights": [
+          "React Native y Expo",
+          "Paneles de progreso",
+          "Recordatorios automatizados de pago"
+        ]
+      },
+      {
+        "id": "slive",
+        "name": "SLIVE.AI",
+        "tagline": "Colaboración empresarial",
+        "description": "SLIVE.AI unifica operaciones ERP, colaboración social y una IA conversacional para orquestar personas, procesos y decisiones en tiempo real.",
+        "highlights": [
+          "ERP + red social interna",
+          "Copilotos de IA conversacional",
+          "Automatización de flujos"
+        ]
+      },
+      {
+        "id": "burger",
+        "name": "Burger Smoke",
+        "tagline": "Menú y pedidos digitales",
+        "description": "Burger Smoke es una experiencia ligera de pedidos que transforma un menú web dinámico en solicitudes de takeout listas para WhatsApp para negocios locales ágiles.",
+        "highlights": [
+          "Actualizaciones del menú en tiempo real",
+          "Pedidos por WhatsApp",
+          "Optimizado para equipos pequeños"
+        ]
+      }
+    ]
   },
   "alt": {
     "wavingHand": "Mano Saludando"


### PR DESCRIPTION
## Summary
- add a reusable Projects section that renders project cards from localized content
- translate the projects showcase and navigation label into English and Spanish
- wire the new section into the home page scroll flow between the stack and experience sections

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6911f97b0c2c832dba3acc2843645a5a)